### PR TITLE
Introduce built-in registry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,48 @@
 PATH
   remote: .
   specs:
-    aux (0.1.1)
+    aux (0.2.0)
       activemodel (>= 6.1, < 8)
-      dry-container (>= 0.9.0, <= 0.11)
+      concurrent-ruby (~> 1.2, >= 1.2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activesupport (6.1.7.3)
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     backports (3.23.0)
-    concurrent-ruby (1.2.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    dry-container (0.11.0)
+    drb (2.2.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    i18n (1.12.0)
-      concurrent-ruby (~> 1.0)
-    json (2.6.2)
-    minitest (5.18.0)
-    parallel (1.22.1)
-    parser (3.1.2.1)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    minitest (5.22.2)
+    mutex_m (0.2.0)
+    parallel (1.24.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
     redcarpet (3.5.1)
-    regexp_parser (2.5.0)
-    rexml (3.2.5)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -46,22 +56,23 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.36.0)
+    rubocop (1.62.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.20.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.21.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
+    ruby-progressbar (1.13.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.5.0)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)
@@ -69,7 +80,7 @@ GEM
       backports (>= 3.18)
       rainbow
       yard
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   ruby
@@ -78,10 +89,10 @@ DEPENDENCIES
   aux!
   redcarpet
   rspec (~> 3.12)
-  rubocop (~> 1.36.0)
+  rubocop (~> 1.62, >= 1.62.1)
   yard
   yard-junk
-  zeitwerk (~> 2.5)
+  zeitwerk (~> 2.6, >= 2.6.13)
 
 BUNDLED WITH
    2.1.4

--- a/aux.gemspec
+++ b/aux.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |specification|
   specification.add_dependency 'concurrent-ruby', '~> 1.2', '>= 1.2.3'
   specification.add_dependency 'activemodel', '>= 6.1', '< 8'
 
-  specification.add_development_dependency 'zeitwerk', '~> 2.5'
-  specification.add_development_dependency 'rubocop', '~> 1.36.0'
+  specification.add_development_dependency 'zeitwerk', '~> 2.6', '>= 2.6.13'
+  specification.add_development_dependency 'rubocop', '~> 1.62', '>= 1.62.1'
 
   specification.required_ruby_version = '>= 2.7.1'
   specification.metadata['rubygems_mfa_required'] = 'true'

--- a/aux.gemspec
+++ b/aux.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |specification|
   specification.email = ['eboyko@eboyko.ru']
   specification.homepage = 'https://github.com/eboyko/aux'
 
+  specification.add_dependency 'concurrent-ruby', '~> 1.2', '>= 1.2.3'
   specification.add_dependency 'activemodel', '>= 6.1', '< 8'
-  specification.add_dependency 'dry-container', '>= 0.9.0', '<= 0.11'
 
   specification.add_development_dependency 'zeitwerk', '~> 2.5'
   specification.add_development_dependency 'rubocop', '~> 1.36.0'

--- a/lib/aux/pluggable.rb
+++ b/lib/aux/pluggable.rb
@@ -4,6 +4,7 @@ require 'aux/pluggable/class_methods'
 require 'aux/pluggable/connector'
 require 'aux/pluggable/dependency'
 require 'aux/pluggable/utilities'
+require 'aux/registry'
 
 module Aux
   # Describes interface that makes any class able to register itself as well as resolve dependencies

--- a/lib/aux/pluggable.rb
+++ b/lib/aux/pluggable.rb
@@ -10,6 +10,8 @@ module Aux
   # Describes interface that makes any class able to register itself as well as resolve dependencies
   # rubocop:disable Style/ClassVars
   module Pluggable
+    @@registry = Aux::Registry.new
+
     # Extends the including class with ClassMethods and initializes a new Connector instance
     # @param base [Class] the class that includes this module
     def self.included(base)
@@ -20,12 +22,19 @@ module Aux
       end
     end
 
-    # @param registry [Dry::Container]
+    # @yield configure the module
+    # @yieldparam pluggable [Module<Aux::Pluggable>]
+    # @yieldparam registry [Aux::Registry]
+    def self.configure
+      yield(self, @@registry) if block_given?
+    end
+
+    # @param registry [Aux::Registry]
     def self.registry=(registry)
       @@registry = registry
     end
 
-    # @return [Dry::Container]
+    # @return [Aux::Registry]
     def self.registry
       @@registry
     end

--- a/lib/aux/pluggable/class_methods.rb
+++ b/lib/aux/pluggable/class_methods.rb
@@ -52,24 +52,19 @@ module Aux
 
       # @param initialize [TrueClass, FalseClass]
       # @param memoize [TrueClass, FalseClass]
-      # @param scope [TrueClass, Symbol, String, nil]
+      # @param scope [Symbol, String, TrueClass, nil]
       # @param as [Symbol, String, nil]
       def register(initialize: false, memoize: false, scope: true, as: nil)
-        @_pluggable.register(
-          initialization_required: initialize,
-          memoization_required: memoize,
-          namespace: scope,
-          code: as
-        )
+        @_pluggable.register(initialize, memoize, scope, as)
       end
 
       # @param code [Symbol, String]
-      # @param initialization_block [Block]
+      # @param initialization_block [Proc, nil]
       # @param scope [TrueClass, Symbol, String, nil]
       # @param private [TrueClass, FalseClass]
       # @param as [Symbol, String, nil]
       def resolve(code, initialization_block = nil, scope: true, private: true, as: nil)
-        @_pluggable.resolve(code, initialization_block, namespace: scope, private: private, as: as)
+        @_pluggable.resolve(code, scope, private, as, initialization_block)
       end
     end
   end

--- a/lib/aux/pluggable/connector.rb
+++ b/lib/aux/pluggable/connector.rb
@@ -3,6 +3,7 @@
 module Aux
   module Pluggable
     # Describes the bridge between a pluggable class and the registry
+    # @!visibility private
     class Connector
       # @!attribute [r] dependencies
       #   @return [Array<Dependency>]

--- a/lib/aux/pluggable/connector.rb
+++ b/lib/aux/pluggable/connector.rb
@@ -9,7 +9,7 @@ module Aux
       attr_reader :dependencies
 
       # @param subject [Class]
-      # @param registry [Dry::Container]
+      # @param registry [Aux::Registry]
       def initialize(subject, registry)
         @subject = subject
         @registry = registry
@@ -44,7 +44,7 @@ module Aux
       # rubocop:disable Layout/LineLength, Metrics/AbcSize, Metrics/MethodLength
       def resolve(code, initialization_block = nil, namespace: true, private: true, as: nil)
         cipher = Utilities.dependency_cipher(@subject.name, scope: namespace, code: code)
-        load_class(cipher) unless @registry.key?(cipher)
+        load_class(cipher)
 
         dependency = Dependency.new(@registry.resolve(cipher), initialization_block, pointer: as || code, private: private)
         @dependencies.push(dependency)

--- a/lib/aux/pluggable/dependency.rb
+++ b/lib/aux/pluggable/dependency.rb
@@ -10,14 +10,14 @@ module Aux
       #   @return [Symbol, String]
       # @!attribute [r] private
       #   @return [Boolean]
-      attr_reader :pointer, :target, :private
+      attr_reader :target, :pointer, :private
 
       # @param target [Object]
-      # @param initialization_block [Proc, nil]
       # @param pointer [Symbol, String]
       # @param private [Boolean]
-      def initialize(target, initialization_block = nil, pointer:, private:)
-        @target = initialization_block ? initialization_block.call(target) : target
+      # @param initialization_block [Proc, nil]
+      def initialize(target, pointer, private, initialization_block = nil)
+        @target = initialization_block&.call(target) || target
         @pointer = pointer
         @private = private
       end

--- a/lib/aux/pluggable/dependency.rb
+++ b/lib/aux/pluggable/dependency.rb
@@ -3,6 +3,7 @@
 module Aux
   module Pluggable
     # Describes the dependency and its preferences
+    # @!visibility private
     class Dependency
       # @!attribute [r] target
       #   @return [Object]

--- a/lib/aux/pluggable/utilities.rb
+++ b/lib/aux/pluggable/utilities.rb
@@ -15,8 +15,8 @@ module Aux
       def self.dependency_cipher(subject, scope, code)
         native_cipher = dependency_native_cipher(subject)
         native_cipher_partitions = native_cipher.rpartition('.')
-        scope = scope == true ? native_cipher_partitions.first : scope
-        code = code.nil? ? native_cipher_partitions.last : code
+        scope = native_cipher_partitions.first if scope == true
+        code = native_cipher_partitions.last if code.nil?
 
         [scope, code].reject { |part| part.nil? || part.empty? }.join('.')
       end
@@ -24,7 +24,7 @@ module Aux
       # @param subject [ClassName]
       # @return [String]
       def self.dependency_native_cipher(subject)
-        subject.dup.gsub(/::/, '.').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+        subject.dup.gsub('::', '.').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
       end
     end
   end

--- a/lib/aux/pluggable/utilities.rb
+++ b/lib/aux/pluggable/utilities.rb
@@ -3,6 +3,7 @@
 module Aux
   module Pluggable
     # Random methods for internal usage
+    # @!visibility private
     module Utilities
       # First, we need to determine the appropriate namespace (also called the scope) in which to resolve something.
       # By default, we assume that the developers want to resolve a dependency from the same namespace as the
@@ -21,7 +22,7 @@ module Aux
         [scope, code].reject { |part| part.nil? || part.empty? }.join('.')
       end
 
-      # @param subject [ClassName]
+      # @param subject [String]
       # @return [String]
       def self.dependency_native_cipher(subject)
         subject.dup.gsub('::', '.').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase

--- a/lib/aux/pluggable/utilities.rb
+++ b/lib/aux/pluggable/utilities.rb
@@ -8,11 +8,11 @@ module Aux
       # By default, we assume that the developers want to resolve a dependency from the same namespace as the
       # referencing class. Another approach is to allow developers to set the correct scope themselves.
       #
-      # @param subject [ClassName]
-      # @param scope [TrueClass, Symbol, String, nil]
-      # @param code [TrueClass, Symbol, String, nil]
+      # @param subject [String]
+      # @param scope [Symbol, String, TrueClass, nil]
+      # @param code [Symbol, String, nil]
       # @return [String]
-      def self.dependency_cipher(subject, scope: nil, code: nil)
+      def self.dependency_cipher(subject, scope, code)
         native_cipher = dependency_native_cipher(subject)
         native_cipher_partitions = native_cipher.rpartition('.')
         scope = scope == true ? native_cipher_partitions.first : scope

--- a/lib/aux/registry.rb
+++ b/lib/aux/registry.rb
@@ -11,13 +11,14 @@ module Aux
     end
 
     # @param key [Symbol, String]
-    # @param memoize [TrueClass, FalseClass, NilClass]
+    # @param memoize [TrueClass, FalseClass]
     # @param constructor [Proc]
     def register(key, memoize: false, &constructor)
       @prototypes.put(key.to_s, Entry.new(constructor, memoize))
     end
 
     # @param key [Symbol, String]
+    # @return [Object]
     def resolve(key)
       @prototypes.fetch(key.to_s).call
     end

--- a/lib/aux/registry.rb
+++ b/lib/aux/registry.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'aux/registry/entry'
+require 'concurrent/map'
+
+module Aux
+  # Registry for dependency injection
+  class Registry
+    def initialize
+      @prototypes = ::Concurrent::Map.new
+    end
+
+    # @param key [Symbol, String]
+    # @param memoize [TrueClass, FalseClass, NilClass]
+    # @param constructor [Proc]
+    def register(key, memoize: false, &constructor)
+      @prototypes.put(key.to_s, Entry.new(constructor, memoize))
+    end
+
+    # @param key [Symbol, String]
+    def resolve(key)
+      @prototypes.fetch(key.to_s).call
+    end
+
+    # @param key [Symbol, String]
+    # @return [TrueClass, FalseClass]
+    def key?(key)
+      @prototypes.key?(key.to_s)
+    end
+  end
+end

--- a/lib/aux/registry/entry.rb
+++ b/lib/aux/registry/entry.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Aux
+  class Registry
+    # Describes a registered dependency
+    # @!visibility private
+    class Entry
+      # @param constructor [Proc]
+      # @param memoization_required [TrueClass, FalseClass]
+      def initialize(constructor, memoization_required)
+        @constructor = constructor
+        @memoization_required = memoization_required
+
+        @mutex = ::Mutex.new
+      end
+
+      # @return [Object]
+      def call
+        return @constructor.call unless @memoization_required
+
+        @call ||= @mutex.synchronize do
+          @constructor.call
+        end
+      end
+    end
+  end
+end

--- a/lib/aux/registry/entry.rb
+++ b/lib/aux/registry/entry.rb
@@ -11,7 +11,7 @@ module Aux
         @constructor = constructor
         @memoization_required = memoization_required
 
-        @mutex = ::Mutex.new
+        @mutex = Thread::Mutex.new
       end
 
       # @return [Object]

--- a/lib/aux/version.rb
+++ b/lib/aux/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aux
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/spec/pluggable_helper.rb
+++ b/spec/pluggable_helper.rb
@@ -1,7 +1,5 @@
 require 'active_support/inflector'
-require 'active_support/dependencies/zeitwerk_integration'
 require 'aux/pluggable'
-require 'dry/container'
 require 'zeitwerk'
 
 # Define some acronym-based inflections using Rails features
@@ -13,8 +11,5 @@ end
 # Preload dummy classes to emulate a real application
 autoloader = Zeitwerk::Loader.new
 autoloader.push_dir("#{__dir__}/dummies/pluggable")
-autoloader.inflector = ActiveSupport::Dependencies::ZeitwerkIntegration::Inflector
+autoloader.inflector = ActiveSupport::Inflector
 autoloader.setup
-
-# Configure the registry
-Aux::Pluggable.registry = Dry::Container.new


### PR DESCRIPTION
Introduced `Aux::Registry`, an integrated registry solution that replaces `Dry::Container`. _It is able to rewrite dependencies_, so that modified classes can be reloaded in real time. Use it when editing code while `rails server` is running in a development environment. It should also work well in production (when no file changes occur), but if you are concerned about this, feel free to use `Dry::Container`.

Notice for `Dry::Container` users: `dry-container` is no longer a dependency. Make sure you have it in your Gemfile when upgrading `Aux` to 0.2.0. 